### PR TITLE
feat: add skeleton transcription server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# app_projects
+# TranscriVA Skeleton Server
+
+This repository contains a minimal Node.js HTTP server that outlines the
+transcription workflow described in the PRD. The `/transcribe` endpoint accepts a JSON body with an `audio_url` field and returns a placeholder transcription. A `/health` endpoint is also provided for basic uptime checks.
+
+## Running locally
+
+```bash
+npm start
+```
+
+## Testing
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "app_projects",
+  "version": "1.0.0",
+  "description": "Skeleton server for TranscriVA MVP",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,41 @@
+const http = require('node:http');
+
+function createApp() {
+  return http.createServer(async (req, res) => {
+    if (req.method === 'POST' && req.url === '/transcribe') {
+      let body = '';
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      let data;
+      try {
+        data = JSON.parse(body);
+      } catch {
+        res.statusCode = 400;
+        res.end('Invalid JSON');
+        return;
+      }
+      const audioUrl = data && data.audio_url ? data.audio_url : 'unknown';
+      const result = {
+        text: `Transcription placeholder for ${audioUrl}`
+      };
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(result));
+    } else if (req.method === 'GET' && req.url === '/health') {
+      res.statusCode = 200;
+      res.end('ok');
+    } else {
+      res.statusCode = 404;
+      res.end('Not Found');
+    }
+  });
+}
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  createApp().listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = { createApp };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { createApp } = require('../src/server');
+
+const fetch = global.fetch;
+
+test('GET /health returns ok', async () => {
+  const server = createApp().listen(0);
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/health`);
+  const text = await res.text();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(text, 'ok');
+  server.close();
+});
+


### PR DESCRIPTION
## Summary
- set up minimal Node.js HTTP server with `/transcribe` and `/health` endpoints
- add basic test for health endpoint
- document how to run and test the server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beefa199b883258520ef8d5142df6e